### PR TITLE
change ruby version to 2.5.1 in order to build on semaphore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.2'
+ruby '2.5.1'
 
 gem 'rails', '~> 5.2.2'
 gem 'pg', '>= 0.18', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,7 @@ DEPENDENCIES
   webpacker (~> 3.5)
 
 RUBY VERSION
-   ruby 2.5.2p104
+   ruby 2.5.1p57
 
 BUNDLED WITH
    1.16.6


### PR DESCRIPTION
In order to build on semaphore we need to have ruby in a supported version.

Change version from 2.5.2 to 2.5.1


![image](https://user-images.githubusercontent.com/45640859/53502931-6209ad80-3aaf-11e9-8fe9-c0371191f7c8.png)
